### PR TITLE
Use bjoern rather than the non-production flask provided WSGI server

### DIFF
--- a/mlapi.py
+++ b/mlapi.py
@@ -17,6 +17,7 @@ import cv2
 import uuid
 import numpy as np
 import argparse
+import bjoern
 
 import modules.common_params as g
 import modules.db as Database
@@ -228,4 +229,5 @@ if __name__ == '__main__':
     g.log.info ('Starting server with max:{} processes'.format
     (g.config['processes']))
     #app.run(host='0.0.0.0', port=5000, threaded=True)
-    app.run(host='0.0.0.0', port=g.config['port'], threaded=False, processes=g.config['processes'])
+    #app.run(host='0.0.0.0', port=g.config['port'], threaded=False, processes=g.config['processes'])
+    bjoern.run(app,host='0.0.0.0',port=g.config['port'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ scikit_learn
 face_recognition
 pyzm>=0.1.22
 portalocker
+bjoern


### PR DESCRIPTION
Currently MLAPI uses the default flask-provided WSGI server, which is not recommended for production use. This pull request changes to using the light-weight C based bjoern WSGI server (https://github.com/jonashaag/bjoern) instead. The downside to this change is that it does add a dependency - bjoern - which in turn has a dependency of libev, which the user would have to manually install.